### PR TITLE
OrElse family function

### DIFF
--- a/src/main/java/com/spencerwi/either/Either.java
+++ b/src/main/java/com/spencerwi/either/Either.java
@@ -156,6 +156,22 @@ public abstract class Either<L, R> {
 	 */
     public abstract <R2> Either<L, R2> flatMapRight(Function<R, Either<L,R2>> transformRight);
 
+    public abstract L getLeftOrElse(L other);
+
+    public abstract L getLeftOrElse(Supplier<L> otherSupplier);
+
+    public abstract <X extends Throwable> L getLeftOrElseThrow(Function<R,X> exceptionFunction) throws X;
+
+    public abstract <X extends Throwable> L getLeftOrElseThrow(Supplier<X> exceptionSupplier) throws X;
+
+    public abstract R getRightOrElse(R other);
+
+    public abstract R getRightOrElse(Supplier<R> otherSupplier);
+
+    public abstract <X extends Throwable> R  getRightOrElseThrow(Function<L,X> exceptionFunction) throws X;
+
+    public abstract <X extends Throwable> R getRightOrElseThrow(Supplier<X> exceptionSupplier) throws X;
+
     public static class Left<L,R> extends Either<L, R> {
 
         protected L leftValue;
@@ -205,6 +221,46 @@ public abstract class Either<L, R> {
         @Override
         public <R2> Either<L, R2> flatMapRight(Function<R, Either<L,R2>> transformRight) {
             return Either.left(leftValue);
+        }
+
+        @Override
+        public L getLeftOrElse(L other) {
+            return leftValue;
+        }
+
+        @Override
+        public  L getLeftOrElse(Supplier<L> otherSupplier) {
+            return leftValue;
+        }
+
+        @Override
+        public <X extends Throwable> L getLeftOrElseThrow(Function<R, X> exceptionFunction) throws X {
+            return leftValue;
+        }
+
+        @Override
+        public <X extends Throwable> L getLeftOrElseThrow(Supplier<X> exceptionSupplier) throws X {
+            return leftValue;
+        }
+
+        @Override
+        public R getRightOrElse(R other) {
+            return other;
+        }
+
+        @Override
+        public R getRightOrElse(Supplier<R> otherSupplier) {
+            return otherSupplier.get();
+        }
+
+        @Override
+        public <X extends Throwable> R getRightOrElseThrow(Function<L, X> exceptionFunction) throws X {
+            throw exceptionFunction.apply(leftValue);
+        }
+
+        @Override
+        public <X extends Throwable> R getRightOrElseThrow(Supplier<X> exceptionSupplier) throws X {
+            throw exceptionSupplier.get();
         }
 
 
@@ -276,6 +332,46 @@ public abstract class Either<L, R> {
         @Override
         public <R2> Either<L, R2> flatMapRight(Function<R, Either<L, R2>> transformRight) {
             return transformRight.apply(rightValue);
+        }
+
+        @Override
+        public L getLeftOrElse(L other) {
+            return other;
+        }
+
+        @Override
+        public L getLeftOrElse(Supplier<L> otherSupplier) {
+            return otherSupplier.get();
+        }
+
+        @Override
+        public <X extends Throwable> L getLeftOrElseThrow(Function<R, X> exceptionFunction) throws X {
+            throw exceptionFunction.apply(rightValue);
+        }
+
+        @Override
+        public <X extends Throwable> L getLeftOrElseThrow(Supplier<X> exceptionSupplier) throws X {
+            throw exceptionSupplier.get();
+        }
+
+        @Override
+        public R getRightOrElse(R other) {
+            return rightValue;
+        }
+
+        @Override
+        public R getRightOrElse(Supplier<R> otherSupplier) {
+            return rightValue;
+        }
+
+        @Override
+        public <X extends Throwable> R getRightOrElseThrow(Function<L, X> exceptionFunction) throws X {
+            return rightValue;
+        }
+
+        @Override
+        public <X extends Throwable> R getRightOrElseThrow(Supplier<X> exceptionSupplier) throws X {
+            return rightValue;
         }
 
 

--- a/src/main/java/com/spencerwi/either/Either.java
+++ b/src/main/java/com/spencerwi/either/Either.java
@@ -156,19 +156,7 @@ public abstract class Either<L, R> {
 	 */
     public abstract <R2> Either<L, R2> flatMapRight(Function<R, Either<L,R2>> transformRight);
 
-    public abstract L getLeftOrElse(L other);
-
-    public abstract L getLeftOrElse(Supplier<L> otherSupplier);
-
-    public abstract <X extends Throwable> L getLeftOrElseThrow(Function<R,X> exceptionFunction) throws X;
-
     public abstract <X extends Throwable> L getLeftOrElseThrow(Supplier<X> exceptionSupplier) throws X;
-
-    public abstract R getRightOrElse(R other);
-
-    public abstract R getRightOrElse(Supplier<R> otherSupplier);
-
-    public abstract <X extends Throwable> R  getRightOrElseThrow(Function<L,X> exceptionFunction) throws X;
 
     public abstract <X extends Throwable> R getRightOrElseThrow(Supplier<X> exceptionSupplier) throws X;
 
@@ -224,38 +212,8 @@ public abstract class Either<L, R> {
         }
 
         @Override
-        public L getLeftOrElse(L other) {
-            return leftValue;
-        }
-
-        @Override
-        public  L getLeftOrElse(Supplier<L> otherSupplier) {
-            return leftValue;
-        }
-
-        @Override
-        public <X extends Throwable> L getLeftOrElseThrow(Function<R, X> exceptionFunction) throws X {
-            return leftValue;
-        }
-
-        @Override
         public <X extends Throwable> L getLeftOrElseThrow(Supplier<X> exceptionSupplier) throws X {
             return leftValue;
-        }
-
-        @Override
-        public R getRightOrElse(R other) {
-            return other;
-        }
-
-        @Override
-        public R getRightOrElse(Supplier<R> otherSupplier) {
-            return otherSupplier.get();
-        }
-
-        @Override
-        public <X extends Throwable> R getRightOrElseThrow(Function<L, X> exceptionFunction) throws X {
-            throw exceptionFunction.apply(leftValue);
         }
 
         @Override
@@ -335,39 +293,10 @@ public abstract class Either<L, R> {
         }
 
         @Override
-        public L getLeftOrElse(L other) {
-            return other;
-        }
-
-        @Override
-        public L getLeftOrElse(Supplier<L> otherSupplier) {
-            return otherSupplier.get();
-        }
-
-        @Override
-        public <X extends Throwable> L getLeftOrElseThrow(Function<R, X> exceptionFunction) throws X {
-            throw exceptionFunction.apply(rightValue);
-        }
-
-        @Override
         public <X extends Throwable> L getLeftOrElseThrow(Supplier<X> exceptionSupplier) throws X {
             throw exceptionSupplier.get();
         }
 
-        @Override
-        public R getRightOrElse(R other) {
-            return rightValue;
-        }
-
-        @Override
-        public R getRightOrElse(Supplier<R> otherSupplier) {
-            return rightValue;
-        }
-
-        @Override
-        public <X extends Throwable> R getRightOrElseThrow(Function<L, X> exceptionFunction) throws X {
-            return rightValue;
-        }
 
         @Override
         public <X extends Throwable> R getRightOrElseThrow(Supplier<X> exceptionSupplier) throws X {

--- a/src/test/java/com/spencerwi/either/EitherTest.java
+++ b/src/test/java/com/spencerwi/either/EitherTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class EitherTest {
 

--- a/src/test/java/com/spencerwi/either/EitherTest.java
+++ b/src/test/java/com/spencerwi/either/EitherTest.java
@@ -339,8 +339,47 @@ public class EitherTest {
         }
     }
 
+    @Nested
+    @DisplayName("Either.OrElseThrow")
+    public class EitherOrElseTest {
+
+        @Test
+        void getLeftOrElseThrowWhenLeft() {
+            Either<String, Integer> leftEither = Either.left("foo");
+
+            assertThat(leftEither.getLeftOrElseThrow(() -> new RuntimeException("Int not accepted"))).isEqualTo("foo");
+        }
+
+        @Test
+        void getLeftOrElseThrowWhenRight() {
+            Either<String, Integer> rightEither = Either.right(1);
+
+            assertThatThrownBy(() -> rightEither.getLeftOrElseThrow(() -> new RuntimeException("String not accepted")))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("String not accepted");
+        }
+
+
+        @Test
+        void getRightOrElseThrowWhenLeft() {
+            Either<String, Integer> leftEither = Either.left("foo");
+
+            assertThatThrownBy(() -> leftEither.getRightOrElseThrow(() -> new RuntimeException("String not accepted")))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("String not accepted");
+        }
+
+        @Test
+        void getRightOrElseThrowWhenRight() {
+            Either<String, Integer> rightEither = Either.right(1);
+            assertThat(rightEither.getRightOrElseThrow(() -> new RuntimeException("Int not accepted"))).isEqualTo(1);
+        }
+    }
+
+
+
     public static class WrapperAroundBoolean {
-        private boolean value; 
+        private boolean value;
         public WrapperAroundBoolean(){ this.value = false; }
         public WrapperAroundBoolean(boolean value) { this.value = value; }
         public void set(boolean value){ this.value = value; }


### PR DESCRIPTION
Modeled on Vavr

I started to use the library in my application and I realized that `Either.getRight()` cannot throw detailed exception.
Then I implemented `getRightOrElseThrow()` and finally whole family **\*OrElse\*** methods.

BTW, comparing to Vavr, killer feature is method `run()` - Vavr Either does not have it.