### PR TITLE
Added EitherCollectors

### DIFF
--- a/src/main/java/com/spencerwi/either/EitherCollectors.java
+++ b/src/main/java/com/spencerwi/either/EitherCollectors.java
@@ -1,0 +1,80 @@
+package com.spencerwi.either;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+public class EitherCollectors<L,R> implements Collector< Either<L,R>, EitherCollectors.EitherAccumulator<L,R>, Either<List<L>, List<R>> > {
+    private final boolean leftBiased;
+
+    public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toLeftBiasedList() {
+        return new EitherCollectors<>(true);
+    }
+
+    public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toRightBiasedList() {
+        return new EitherCollectors<>(false);
+    }
+
+    private EitherCollectors(boolean leftBiased) {
+        this.leftBiased = leftBiased;
+    }
+
+    @Override
+    public Supplier<EitherAccumulator<L, R>> supplier() {
+        return () -> new EitherAccumulator<>(leftBiased);
+    }
+
+    @Override
+    public BiConsumer<EitherAccumulator<L, R>, Either<L, R>> accumulator() {
+        return EitherAccumulator::add;
+    }
+
+    @Override
+    public BinaryOperator<EitherAccumulator<L, R>> combiner() {
+        return EitherAccumulator::append;
+    }
+
+    @Override
+    public Function<EitherAccumulator<L, R>, Either<List<L>, List<R>>> finisher() {
+        return EitherAccumulator::finisher;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return Collections.unmodifiableSet(EnumSet.of(Characteristics.CONCURRENT));
+    }
+
+    static class EitherAccumulator<L,R> {
+        private final List<L> lefts;
+        private final List<R> rights;
+        private final boolean leftBiased;
+
+        EitherAccumulator(boolean leftBiased) {
+            this.leftBiased = leftBiased;
+            this.lefts = new ArrayList<>();
+            this.rights = new ArrayList<>();
+        }
+
+        void add(Either<L,R> e) {
+            e.run(lefts::add, rights::add);
+        }
+
+        EitherAccumulator<L,R> append(EitherAccumulator<L,R> accumulator2) {
+            lefts.addAll(accumulator2.lefts);
+            rights.addAll(accumulator2.rights);
+            return this;
+        }
+
+        Either<List<L>, List<R>> finisher() {
+            if(leftBiased) {
+                return !lefts.isEmpty() ? Either.left(lefts) : Either.right(rights);
+            } else {
+                return !rights.isEmpty() ? Either.right(rights) : Either.left(lefts);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/spencerwi/either/EitherCollectors.java
+++ b/src/main/java/com/spencerwi/either/EitherCollectors.java
@@ -7,13 +7,33 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
+/**
+ * These collectors collect a stream of Either<L,R> objects to an
+ * Either<List<L>, List<R>> object.
+ *
+ * The left biased collector will produce a left Either if the stream is empty
+ * or contains at least one left Either objects.
+ *
+ * The right biased collector will produce a right Either if the stream is empty
+ * or contains at least one right Either objects.
+ *
+ * @param <L> the "left side" type.
+ * @param <R> the "right side type.
+ */
+
 public class EitherCollectors<L,R> implements Collector< Either<L,R>, EitherCollectors.EitherAccumulator<L,R>, Either<List<L>, List<R>> > {
     private final boolean leftBiased;
 
+    /**
+    * Factory method for creating a left biased collector
+    */
     public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toLeftBiasedList() {
         return new EitherCollectors<>(true);
     }
 
+    /**
+     * Factory method for creating a right biased collector
+     */
     public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toRightBiasedList() {
         return new EitherCollectors<>(false);
     }
@@ -70,9 +90,9 @@ public class EitherCollectors<L,R> implements Collector< Either<L,R>, EitherColl
 
         Either<List<L>, List<R>> finisher() {
             if(leftBiased) {
-                return !lefts.isEmpty() ? Either.left(lefts) : Either.right(rights);
+                return !lefts.isEmpty() || rights.isEmpty()  ? Either.left(lefts) : Either.right(rights);
             } else {
-                return !rights.isEmpty() ? Either.right(rights) : Either.left(lefts);
+                return !rights.isEmpty() || lefts.isEmpty() ? Either.right(rights) : Either.left(lefts);
             }
         }
     }

--- a/src/main/java/com/spencerwi/either/EitherCollectors.java
+++ b/src/main/java/com/spencerwi/either/EitherCollectors.java
@@ -8,14 +8,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 /**
- * These collectors collect a stream of Either<L,R> objects to an
- * Either<List<L>, List<R>> object.
- *
- * The left biased collector will produce a left Either if the stream is empty
- * or contains at least one left Either objects.
- *
- * The right biased collector will produce a right Either if the stream is empty
- * or contains at least one right Either objects.
+ * These collectors collect a stream of Either<L,R> objects to an Either<List<L>, List<R>> object.
  *
  * @param <L> the "left side" type.
  * @param <R> the "right side type.
@@ -25,16 +18,24 @@ public class EitherCollectors<L,R> implements Collector< Either<L,R>, EitherColl
     private final boolean leftBiased;
 
     /**
-    * Factory method for creating a left biased collector
-    */
-    public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toLeftBiasedList() {
+     * Factory method for creating a left biased collector which produces an Either<List<L>, List<R>> object,
+     * where the list contains all the left or right Either values of the stream.
+     * Since this is a left biased collector, the resulting Either is left iff the stream is empty or contains
+     * at least one left Either object.
+     * @return Either<List<L>, List<R>>
+     */
+    public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toLeftBiased() {
         return new EitherCollectors<>(true);
     }
 
     /**
-     * Factory method for creating a right biased collector
+     * Factory method for creating a right biased collector which produces an Either<List<L>, List<R>> object,
+     * where the list contains all the left or right Either values of the stream.
+     * Since this is a right biased collector, the resulting Either is right iff the stream is empty or contains
+     * at least one right Either object.
+     * @return Either<List<L>, List<R>>
      */
-    public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toRightBiasedList() {
+    public static <L,R> Collector<Either<L,R>, ?, Either<List<L>, List<R>>> toRightBiased() {
         return new EitherCollectors<>(false);
     }
 

--- a/src/test/java/com/spencerwi/either/EitherCollectorsTest.java
+++ b/src/test/java/com/spencerwi/either/EitherCollectorsTest.java
@@ -1,0 +1,54 @@
+package com.spencerwi.either;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("EitherCollectors with Java")
+public class EitherCollectorsTest {
+
+    @Test
+    public void checkBiasedCollectors(){
+        Either<String, Integer> either1 = Either.left("left");
+        Either<String, Integer> either2 = Either.right(42);
+
+        List<Either<String, Integer>> listOfEithers = Stream.of(either1, either2).collect(Collectors.toList());
+
+        // left
+        Either<List<String>, List<Integer>> leftBiasedList = listOfEithers.stream().collect(EitherCollectors.toLeftBiasedList());
+
+        assertThat(leftBiasedList).isInstanceOf(Either.Left.class);
+        assertThat(leftBiasedList.getLeft().size()).isEqualTo(1);
+        assertThat(leftBiasedList.getLeft().get(0)).isEqualTo(either1.getLeft());
+
+        // right
+        Either<List<String>, List<Integer>> rightBiasedList = listOfEithers.stream().collect(EitherCollectors.toRightBiasedList());
+
+        assertThat(rightBiasedList).isInstanceOf(Either.Right.class);
+        assertThat(rightBiasedList.getRight().size()).isEqualTo(1);
+        assertThat(rightBiasedList.getRight().get(0)).isEqualTo(either2.getRight());
+    }
+
+
+    @Test
+    public void checkEmptyStreamLogic(){
+        Either<List<String>, List<Integer>> leftBiasedList =
+                new ArrayList< Either<String, Integer> >().stream().collect(EitherCollectors.toLeftBiasedList());
+
+        assertThat(leftBiasedList).isInstanceOf(Either.Left.class);
+        assertThat(leftBiasedList.getLeft()).isEmpty();
+
+        Either<List<String>, List<Integer>> rightBiasedList =
+                new ArrayList< Either<String, Integer> >().stream().collect(EitherCollectors.toRightBiasedList());
+
+        assertThat(rightBiasedList).isInstanceOf(Either.Right.class);
+        assertThat(rightBiasedList.getRight()).isEmpty();
+    }
+
+}

--- a/src/test/java/com/spencerwi/either/EitherCollectorsTest.java
+++ b/src/test/java/com/spencerwi/either/EitherCollectorsTest.java
@@ -15,40 +15,43 @@ public class EitherCollectorsTest {
 
     @Test
     public void checkBiasedCollectors(){
-        Either<String, Integer> either1 = Either.left("left");
-        Either<String, Integer> either2 = Either.right(42);
+        Either<String, Integer> eitherLeft1 = Either.left("left1");
+        Either<String, Integer> eitherLeft2 = Either.left("left2");
 
-        List<Either<String, Integer>> listOfEithers = Stream.of(either1, either2).collect(Collectors.toList());
+        Either<String, Integer> eitherRight1 = Either.right(1);
+        Either<String, Integer> eitherRight2 = Either.right(2);
+        Either<String, Integer> eitherRight3 = Either.right(3);
+
+        List<Either<String, Integer>> listOfEithers = Stream.of(eitherLeft1, eitherRight1, eitherLeft2, eitherRight2, eitherRight3)
+                .collect(Collectors.toList());
 
         // left
-        Either<List<String>, List<Integer>> leftBiasedList = listOfEithers.stream().collect(EitherCollectors.toLeftBiasedList());
+        Either<List<String>, List<Integer>> eitherLeftList = listOfEithers.stream().collect(EitherCollectors.toLeftBiased());
 
-        assertThat(leftBiasedList).isInstanceOf(Either.Left.class);
-        assertThat(leftBiasedList.getLeft().size()).isEqualTo(1);
-        assertThat(leftBiasedList.getLeft().get(0)).isEqualTo(either1.getLeft());
+        assertThat(eitherLeftList).isInstanceOf(Either.Left.class);
+        assertThat(eitherLeftList.getLeft().size()).isEqualTo(2);
 
         // right
-        Either<List<String>, List<Integer>> rightBiasedList = listOfEithers.stream().collect(EitherCollectors.toRightBiasedList());
+        Either<List<String>, List<Integer>> eitherRightList = listOfEithers.stream().collect(EitherCollectors.toRightBiased());
 
-        assertThat(rightBiasedList).isInstanceOf(Either.Right.class);
-        assertThat(rightBiasedList.getRight().size()).isEqualTo(1);
-        assertThat(rightBiasedList.getRight().get(0)).isEqualTo(either2.getRight());
+        assertThat(eitherRightList).isInstanceOf(Either.Right.class);
+        assertThat(eitherRightList.getRight().size()).isEqualTo(3);
     }
 
 
     @Test
     public void checkEmptyStreamLogic(){
-        Either<List<String>, List<Integer>> leftBiasedList =
-                new ArrayList< Either<String, Integer> >().stream().collect(EitherCollectors.toLeftBiasedList());
+        Either<List<String>, List<Integer>> eitherLeftList =
+                new ArrayList< Either<String, Integer> >().stream().collect(EitherCollectors.toLeftBiased());
 
-        assertThat(leftBiasedList).isInstanceOf(Either.Left.class);
-        assertThat(leftBiasedList.getLeft()).isEmpty();
+        assertThat(eitherLeftList).isInstanceOf(Either.Left.class);
+        assertThat(eitherLeftList.getLeft()).isEmpty();
 
-        Either<List<String>, List<Integer>> rightBiasedList =
-                new ArrayList< Either<String, Integer> >().stream().collect(EitherCollectors.toRightBiasedList());
+        Either<List<String>, List<Integer>> eitherRightList =
+                new ArrayList< Either<String, Integer> >().stream().collect(EitherCollectors.toRightBiased());
 
-        assertThat(rightBiasedList).isInstanceOf(Either.Right.class);
-        assertThat(rightBiasedList.getRight()).isEmpty();
+        assertThat(eitherRightList).isInstanceOf(Either.Right.class);
+        assertThat(eitherRightList.getRight()).isEmpty();
     }
 
 }


### PR DESCRIPTION
Hi - perhaps you'd be interested in pulling this addition of Collectors to your Either project. Basically the EitherCollectors class adds a left and a right biased collectors for streams of Either<> objects:

```
List<Either<String,Integer>> listOfEithers = ...;

Either<List<String>,List<Integer>>  eitherList = listOfEithers.collect(EitherCollectors.toLeftBiasedList());
```
I've been using it in a couple of projects and found it useful for batch processing lists of requests. If one request cannot be processed the entire batch is rejected.  

I'd be happy to write tests for it.