### PR TITLE
Add getOrElse taking a Supplier to Result

### DIFF
--- a/src/main/java/com/spencerwi/either/Result.java
+++ b/src/main/java/com/spencerwi/either/Result.java
@@ -55,6 +55,16 @@ public abstract class Result<R> {
 	 */
     public abstract R getResult();
 
+    /**
+     * @return the wrapped value if this is an `Ok`, otherwise, the supplied other value.
+     */
+    public R getOrElse(R other) {
+        return fold(
+            exception -> other,
+            Function.identity()
+        );
+    }
+
     public abstract boolean isErr();
     public abstract boolean isOk();
 

--- a/src/main/java/com/spencerwi/either/Result.java
+++ b/src/main/java/com/spencerwi/either/Result.java
@@ -1,6 +1,7 @@
 package com.spencerwi.either;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -63,6 +64,16 @@ public abstract class Result<R> {
         return fold(
             exception -> other,
             Function.identity()
+        );
+    }
+
+    /**
+     * @return the result as an Optional.
+     */
+    public Optional<R> toOptional() {
+        return fold(
+            exception -> Optional.empty(),
+            Optional::ofNullable
         );
     }
 

--- a/src/main/java/com/spencerwi/either/Result.java
+++ b/src/main/java/com/spencerwi/either/Result.java
@@ -3,6 +3,7 @@ package com.spencerwi.either;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * A useful class to wrap operations that may throw exceptions and convert 
@@ -95,7 +96,16 @@ public abstract class Result<R> {
 	 */
     public abstract <T> Result<T> flatMap(ExceptionThrowingFunction<R, Result<T>> transformValue);
 
-	/**
+    /**
+     * Returns the wrapped value if this is an `Ok` ; otherwise throws
+     * the exception supplied by `exceptionSupplier`.
+     * @param exceptionSupplier a Supplier that returns a Throwable that will be thrown if this is an `Err`.
+     * @return the wrapped value if this is an `Ok`.
+     * @throws X if this is an `Err`.
+     */
+    public abstract <X extends Throwable> R getOrElseThrow(Supplier<X> exceptionSupplier) throws X;
+
+    /**
 	 * Runs the acceptsOkValue function if this is an `Ok` instead of an `Err`,
 	 * passing in the value that `Ok` wraps; otherwise, does nothing. Does not 
 	 * return a value. If you need to transform a `Result<T>`, use {@link #map}
@@ -140,7 +150,13 @@ public abstract class Result<R> {
         public <T> Result<T> flatMap(ExceptionThrowingFunction<R, Result<T>> transformValue) {
             return Result.<T>err(this.ex);
         }
-		@Override
+
+        @Override
+        public <X extends Throwable> R getOrElseThrow(Supplier<X> exceptionSupplier) throws X {
+            throw exceptionSupplier.get();
+        }
+
+        @Override
 		public void ifOk(Consumer<R> acceptsOkValue) { /* no-op */ }
 		@Override
 		public void run(Consumer<Exception> errorHandler, Consumer<R> okHandler) {
@@ -198,7 +214,13 @@ public abstract class Result<R> {
                 return new Err<T>(e);
             }
         }
-		@Override
+
+        @Override
+        public <X extends Throwable> R getOrElseThrow(Supplier<X> exceptionSupplier) throws X {
+            return resultValue;
+        }
+
+        @Override
 		public void ifOk(Consumer<R> acceptsOkValue) {
 			acceptsOkValue.accept(this.resultValue);
 		}

--- a/src/main/java/com/spencerwi/either/Result.java
+++ b/src/main/java/com/spencerwi/either/Result.java
@@ -68,6 +68,16 @@ public abstract class Result<R> {
     }
 
     /**
+     * @return the wrapped value if this is an `Ok`, otherwise, the value supplied by `otherSupplier`.
+     */
+    public R getOrElse(Supplier<R> otherSupplier) {
+        return fold(
+                exception -> otherSupplier.get(),
+                Function.identity()
+        );
+    }
+
+    /**
      * @return the result as an Optional.
      */
     public Optional<R> toOptional() {

--- a/src/test/java/com/spencerwi/either/ResultTest.java
+++ b/src/test/java/com/spencerwi/either/ResultTest.java
@@ -9,6 +9,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Result with Java")
 public class ResultTest {
@@ -128,6 +129,16 @@ public class ResultTest {
 			assertThat(wasErrHandlerCalled.value).isTrue();
 			assertThat(wasOkHandlerCalled.value).isFalse();
 		}
+        @Test
+        void throwsSuppliedException_when_getOrElseThrow() {
+            Result<String> err = Result.err(new RuntimeException());
+
+            assertThatThrownBy(() -> err.getOrElseThrow(() -> new RuntimeException("Int not accepted")))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Int not accepted");
+        }
+
+
         @Test
         public void isEqualToOtherErrsHavingTheSameErrValue(){
             Exception ex = new Exception("Test");
@@ -254,6 +265,11 @@ public class ResultTest {
 			assertThat(wasOkHandlerCalled.value).isTrue();
 			assertThat(wasErrHandlerCalled.value).isFalse();
 		}
+        @Test
+        void returnsValue_when_getOrElseThrow() {
+            Result<Integer> ok = Result.ok(1);
+            assertThat(ok.getOrElseThrow(() -> new RuntimeException("Int not accepted"))).isEqualTo(1);
+        }
         @Test
         public void isEqualToOtherOksHavingTheSameResultValue(){
             Result<Integer> resultIs42     = Result.ok(42);

--- a/src/test/java/com/spencerwi/either/ResultTest.java
+++ b/src/test/java/com/spencerwi/either/ResultTest.java
@@ -70,10 +70,12 @@ public class ResultTest {
         }
 
         @Test
-        public void returnsOther_whenGetOrElsed(){
-            Integer result = Result.attempt(() -> 1 / 0).getOrElse(0);
+        public void returnsOther_whenGetOrElse(){
+            Integer result1 = Result.attempt(() -> 1 / 0).getOrElse(0);
+            Integer result2 = Result.attempt(() -> 1 / 0).getOrElse(() -> 0);
 
-            assertThat(result).isEqualTo(0);
+            assertThat(result1).isEqualTo(0);
+            assertThat(result2).isEqualTo(0);
         }
 
         @Test
@@ -213,10 +215,12 @@ public class ResultTest {
         }
 
         @Test
-        public void returnsValue_whenGetOrElsed(){
-            Integer result = Result.attempt(() -> 8/2).getOrElse(0);
+        public void returnsValue_whenGetOrElse(){
+            Integer result1 = Result.attempt(() -> 8/2).getOrElse(0);
+            Integer result2 = Result.attempt(() -> 8/2).getOrElse(() -> 0);
 
-            assertThat(result).isEqualTo(4);
+            assertThat(result1).isEqualTo(4);
+            assertThat(result2).isEqualTo(4);
         }
 
         @Test

--- a/src/test/java/com/spencerwi/either/ResultTest.java
+++ b/src/test/java/com/spencerwi/either/ResultTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -73,6 +74,13 @@ public class ResultTest {
             Integer result = Result.attempt(() -> 1 / 0).getOrElse(0);
 
             assertThat(result).isEqualTo(0);
+        }
+
+        @Test
+        public void returnsEmptyOptional_whenToOptional(){
+            Optional<Object> optional = Result.err(new RuntimeException()).toOptional();
+
+            assertThat(optional).isEmpty();
         }
 
         @Test
@@ -209,6 +217,13 @@ public class ResultTest {
             Integer result = Result.attempt(() -> 8/2).getOrElse(0);
 
             assertThat(result).isEqualTo(4);
+        }
+
+        @Test
+        public void returnsNonEmptyOptional_whenToOptional(){
+            Optional<Integer> optional = Result.ok(1).toOptional();
+
+            assertThat(optional.orElse(0)).isEqualTo(1);
         }
 
         @Test

--- a/src/test/java/com/spencerwi/either/ResultTest.java
+++ b/src/test/java/com/spencerwi/either/ResultTest.java
@@ -68,6 +68,13 @@ public class ResultTest {
         }
 
         @Test
+        public void returnsOther_whenGetOrElsed(){
+            Integer result = Result.attempt(() -> 1 / 0).getOrElse(0);
+
+            assertThat(result).isEqualTo(0);
+        }
+
+        @Test
         public void executesErrTransformation_whenFolded(){
             Result<Integer> errOnly = Result.err(new Exception("Error! Failed!"));
 
@@ -184,6 +191,13 @@ public class ResultTest {
 
             assertThat(ok.isOk()).isTrue();
             assertThat(ok.isErr()).isFalse();
+        }
+
+        @Test
+        public void returnsValue_whenGetOrElsed(){
+            Integer result = Result.attempt(() -> 8/2).getOrElse(0);
+
+            assertThat(result).isEqualTo(4);
         }
 
         @Test


### PR DESCRIPTION
I previously contributed a _getOrElse_ that took a value of the required type. This pull request complements that with an overloaded method that takes a Supplier providing the required value. 